### PR TITLE
Fix Spectre rule style handling and cleanup window cmdlet

### DIFF
--- a/Public/New-SpectreRule.ps1
+++ b/Public/New-SpectreRule.ps1
@@ -21,12 +21,12 @@
     }
     $rule = [Spectre.Console.Rule]::new($PreparedText)
     $rule.Justification = $Align
-    if ($RuleColor -and $Style) {
-        $rule.Style = "$RuleColor $style"
+    if ($RuleColor -and $RuleStyle) {
+        $rule.Style = "$RuleColor $RuleStyle"
     } elseif ($RuleColor) {
-        $Rule.Style = $RuleColor
-    } elseif ($Style) {
-        $Rule.Style = $Style
+        $rule.Style = $RuleColor
+    } elseif ($RuleStyle) {
+        $rule.Style = $RuleStyle
     }
     [Spectre.Console.AnsiConsole]::Render($rule)
 }

--- a/Public/New-TerminalWindow.ps1
+++ b/Public/New-TerminalWindow.ps1
@@ -18,6 +18,5 @@
         }
     }
 
-    $Window.Add($btn)
     $Window
 }


### PR DESCRIPTION
## Summary
- fix variable name in `New-SpectreRule`
- drop undeclared `$btn` from `New-TerminalWindow`

## Testing
- `apt-get update`
- `apt-get install -y powershell` *(fails: Unable to locate package powershell)*

------
https://chatgpt.com/codex/tasks/task_e_683f4010bcb0832ea507181509644777