### PR TITLE
Fix PowerShell Gallery preview badge

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -1,7 +1,7 @@
 ﻿<p align="center">
   <a href="https://dev.azure.com/evotecpl/ConsoleMonster/_build/results?buildId=latest"><img src="https://img.shields.io/azure-devops/build/evotecpl/39c74615-8f34-4af0-a835-68dc33f9214f/14?label=Azure%20Pipelines&style=flat-square"></a>
   <a href="https://www.powershellgallery.com/packages/ConsoleMonster"><img src="https://img.shields.io/powershellgallery/v/ConsoleMonster.svg?style=flat-square"></a>
-  <a href="https://www.powershellgallery.com/packages/ConsoleMonster"><img src="https://img.shields.io/powershellgallery/vpre/ConsoleMonster.svg?label=powershell%20gallery%20preview&colorB=yellow&style=flat-square"></a>
+  <a href="https://www.powershellgallery.com/packages/ConsoleMonster"><img src="https://img.shields.io/powershellgallery/v/ConsoleMonster.svg?label=powershell%20gallery%20preview&colorB=yellow&style=flat-square&include_prereleases"></a>
   <a href="https://github.com/EvotecIT/ConsoleMonster"><img src="https://img.shields.io/github/license/EvotecIT/ConsoleMonster.svg?style=flat-square"></a>
 </p>
 


### PR DESCRIPTION
Shields changed the PowerShell Gallery prerelease badge endpoint and the old vpre badge now renders a placeholder link.

This updates README badge URLs to use the normal PowerShell Gallery version badge with include_prereleases, so it displays the prerelease version again.

Ref: https://github.com/badges/shields/issues/11583