### PR TITLE
chore(deps): patch ImageSharp security advisory

### DIFF
--- a/Sources/ConsoleMonster/ConsoleMonster.csproj
+++ b/Sources/ConsoleMonster/ConsoleMonster.csproj
@@ -17,7 +17,7 @@
 		<PackageReference Include="Spectre.Console.ImageSharp" Version="0.48.0" />
 		<PackageReference Include="Terminal.Gui" Version="1.17.1" />
 		<PackageReference Include="System.Memory" Version="4.5.5" />
-		<PackageReference Include="SixLabors.ImageSharp" Version="2.1.9" />
+		<PackageReference Include="SixLabors.ImageSharp" Version="2.1.11" />
 		<PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
 	</ItemGroup>
 


### PR DESCRIPTION
Fixes the open ImageSharp Dependabot alerts by bumping SixLabors.ImageSharp from 2.1.9 to 2.1.11.\n\nValidation:\n- dotnet build .\\Sources\\ConsoleMonster.sln -c Release -m:1 /p:UseSharedCompilation=false